### PR TITLE
Extended Chromium & ios12 rules

### DIFF
--- a/samesite-global.conf
+++ b/samesite-global.conf
@@ -24,8 +24,10 @@ Header onsuccess edit Set-Cookie "(.*(\s+|;)(?i)Secure(\s+|;).*) Secure$" "$1" e
 # Simplified checks not requiring mod_rewrite and vhost config
 # https://www.chromium.org/updates/same-site/incompatible-clients
 # https://catchjs.com/Blog/SameSiteCookies
+BrowserMatch "OS 12*applewebkit" SAMESITE_SKIP=1
 BrowserMatch "OS 12_.*CriOS" SAMESITE_SKIP=1
 BrowserMatch "Chrome/[56]" SAMESITE_SKIP=1
+BrowserMatch "Chromium/[56]" SAMESITE_SKIP=1
 BrowserMatch "OS X 10_14_.*Version/.*Safari"    SAMESITE_SKIP=1
 BrowserMatch "OS X 10_14_.*(KHTML, like Gecko)" SAMESITE_SKIP=1
 


### PR DESCRIPTION
Added 2 new rules according F5 & Chromium documentation

https://www.chromium.org/updates/same-site/incompatible-clients
https://devcentral.f5.com/s/articles/iRule-to-set-SameSite-for-compatible-clients-and-remove-it-for-incompatible-clients-LTM-ASM-APM